### PR TITLE
Fix: Correct Font Awesome icon rendering

### DIFF
--- a/style.css
+++ b/style.css
@@ -185,3 +185,16 @@ text-align: right;
 .status-right span {
     margin: 0 8px;
 }
+
+/* --- FIX for FontAwesome Icons --- */
+/* For regular/solid icons */
+.fas {
+    font-family: "Font Awesome 6 Free", sans-serif;
+    font-weight: 900;
+}
+
+/* For brand icons */
+.fab {
+    font-family: "Font Awesome 6 Brands", sans-serif;
+    font-weight: 400;
+}


### PR DESCRIPTION
The Font Awesome icons were not displaying because the browser was not applying the correct font family to the `<i>` elements.

This change adds specific CSS rules to `style.css` to target the `.fas` (solid) and `.fab` (brands) classes. It sets the appropriate `font-family` ("Font Awesome 6 Free" and "Font Awesome 6 Brands") and `font-weight` for each style, ensuring the icons render as intended.